### PR TITLE
Add support for character shadows to GeometryInstance node type

### DIFF
--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -350,6 +350,7 @@ GeometryInstance::GeometryInstance() {
 	}
 
 	shadow_casting_setting = SHADOW_CASTING_SETTING_ON;
+	character_shadow_casting_setting = SHADOW_CASTING_SETTING_OFF;
 	extra_cull_margin = 0;
 	//VS::get_singleton()->instance_geometry_set_baked_light_texture_index(get_instance(),0);
 }

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -349,7 +349,7 @@ GeometryInstance::GeometryInstance() {
 		flags[i] = false;
 	}
 
-	shadow_casting_setting = SHADOW_CASTING_SETTING_ON;
+	shadow_casting_setting = SHADOW_CASTING_SETTING_OFF;
 	character_shadow_casting_setting = SHADOW_CASTING_SETTING_OFF;
 	extra_cull_margin = 0;
 	//VS::get_singleton()->instance_geometry_set_baked_light_texture_index(get_instance(),0);

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -259,6 +259,19 @@ GeometryInstance::ShadowCastingSetting GeometryInstance::get_cast_shadows_settin
 	return shadow_casting_setting;
 }
 
+void GeometryInstance::set_cast_character_shadows_setting(ShadowCastingSetting p_shadow_casting_setting) {
+
+	character_shadow_casting_setting = p_shadow_casting_setting;
+
+	//TODO: See if it's necessary to report this to the VS Singleton later.
+	//VS::get_singleton()->instance_geometry_set_cast_shadows_setting(get_instance(), (VS::ShadowCastingSetting)p_shadow_casting_setting);
+}
+
+GeometryInstance::ShadowCastingSetting GeometryInstance::get_cast_character_shadows_setting() const {
+
+	return character_shadow_casting_setting;
+}
+
 void GeometryInstance::set_extra_cull_margin(float p_margin) {
 
 	ERR_FAIL_COND(p_margin < 0);
@@ -281,6 +294,9 @@ void GeometryInstance::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_cast_shadows_setting", "shadow_casting_setting"), &GeometryInstance::set_cast_shadows_setting);
 	ClassDB::bind_method(D_METHOD("get_cast_shadows_setting"), &GeometryInstance::get_cast_shadows_setting);
+	
+	ClassDB::bind_method(D_METHOD("set_cast_character_shadows_setting", "character_shadow_casting_setting"), &GeometryInstance::set_cast_character_shadows_setting);
+	ClassDB::bind_method(D_METHOD("get_cast_character_shadows_setting"), &GeometryInstance::get_cast_character_shadows_setting);
 
 	ClassDB::bind_method(D_METHOD("set_lod_max_hysteresis", "mode"), &GeometryInstance::set_lod_max_hysteresis);
 	ClassDB::bind_method(D_METHOD("get_lod_max_hysteresis"), &GeometryInstance::get_lod_max_hysteresis);
@@ -302,6 +318,7 @@ void GeometryInstance::_bind_methods() {
 	ADD_GROUP("Geometry", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_override", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,SpatialMaterial"), "set_material_override", "get_material_override");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), "set_cast_shadows_setting", "get_cast_shadows_setting");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "cast_character_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), "set_cast_character_shadows_setting", "get_cast_character_shadows_setting");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "extra_cull_margin", PROPERTY_HINT_RANGE, "0,16384,0.01"), "set_extra_cull_margin", "get_extra_cull_margin");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "use_in_baked_light"), "set_flag", "get_flag", FLAG_USE_BAKED_LIGHT);
 

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -102,6 +102,7 @@ public:
 private:
 	bool flags[FLAG_MAX];
 	ShadowCastingSetting shadow_casting_setting;
+	ShadowCastingSetting character_shadow_casting_setting;
 	Ref<Material> material_override;
 	float lod_min_distance;
 	float lod_max_distance;
@@ -120,6 +121,9 @@ public:
 
 	void set_cast_shadows_setting(ShadowCastingSetting p_shadow_casting_setting);
 	ShadowCastingSetting get_cast_shadows_setting() const;
+	
+	void set_cast_character_shadows_setting(ShadowCastingSetting p_shadow_casting_setting);
+	ShadowCastingSetting get_cast_character_shadows_setting() const;
 
 	void set_lod_min_distance(float p_dist);
 	float get_lod_min_distance() const;


### PR DESCRIPTION
Still need to review what the VS::Singleton() is used for in the setter.