### PR TITLE
Fixed Windows dependency in core

### DIFF
--- a/core/io/dir_access_hybrid.cpp
+++ b/core/io/dir_access_hybrid.cpp
@@ -1,6 +1,5 @@
 #include "core/io/dir_access_hybrid.h"
 #include "core/io/file_access_pack.h"
-#include "drivers/windows/dir_access_windows.h"
 
 Error DirAccessHybrid::list_dir_begin() {
 
@@ -167,12 +166,12 @@ String DirAccessHybrid::get_filesystem_type() const {
 	return dir_access_os->get_filesystem_type();
 }
 
-DirAccessHybrid::DirAccessHybrid() :
-		dir_access_os(memnew(DirAccessWindows)),
-		dir_access_pack(memnew(DirAccessPack)),
-		err_os(OK),
-		err_pack(OK),
-		cdir(false) {
+DirAccessHybrid::DirAccessHybrid(){
+		dir_access_os = DirAccess::create(AccessType::ACCESS_FILESYSTEM);
+		dir_access_pack = memnew(DirAccessPack);
+		err_os = OK;
+		err_pack = OK;
+		cdir = false;
 }
 
 DirAccessHybrid::~DirAccessHybrid() {


### PR DESCRIPTION
This changes what `DirAccessHybrid`'s constructor accesses to initialize `dir_access_os`, to be platform agnostic. Now, it should behave the same as before, but can now be compiled on platforms that aren't Windows.